### PR TITLE
Add default implementation for shardDefinitions method

### DIFF
--- a/core/src/main/java/io/github/seonwkim/shard/SharderDatabase.java
+++ b/core/src/main/java/io/github/seonwkim/shard/SharderDatabase.java
@@ -1,5 +1,6 @@
 package io.github.seonwkim.shard;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -17,7 +18,9 @@ public interface SharderDatabase {
     /**
      * The shard definitions for the database.
      */
-    List<ShardDefinition> shardDefinitions();
+    default List<ShardDefinition> shardDefinitions() {
+        return Collections.emptyList();
+    }
 
     /**
      * The shard definitions grouped by table name. Used for quick lookup.

--- a/core/src/test/java/io/github/seonwkim/SimpleQueryShardMatcherTest.java
+++ b/core/src/test/java/io/github/seonwkim/SimpleQueryShardMatcherTest.java
@@ -1,7 +1,5 @@
 package io.github.seonwkim;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -11,10 +9,45 @@ import org.junit.jupiter.api.Test;
 import io.github.seonwkim.shard.DefaultSharderDatabase;
 import io.github.seonwkim.shard.ShardDefinitionMod;
 import io.github.seonwkim.shard.ShardDefinitionRange;
+import io.github.seonwkim.shard.SharderDatabase;
 
 class SimpleQueryShardMatcherTest {
 
     SimpleQueryShardMatcher matcher = new SimpleQueryShardMatcher();
+
+    @Test
+    void shard_should_match_all_when_no_shard_definition_exists_1() {
+        final SharderDatabase shard1 = new SharderDatabase() {
+            @Override
+            public String databaseName() {
+                return "shard1";
+            }
+        };
+        final SharderDatabase shard2 = new SharderDatabase() {
+            @Override
+            public String databaseName() {
+                return "shard2";
+            }
+        };
+
+        final String query1 = "SELECT * FROM person;";
+        AssertionsForClassTypes.assertThat(matcher.match(query1, shard1)).isTrue();
+        AssertionsForClassTypes.assertThat(matcher.match(query1, shard2)).isTrue();
+    }
+
+    @Test
+    void shard_should_match_all_when_no_shard_definition_exists() {
+        final DefaultSharderDatabase shard1 = new DefaultSharderDatabase("shard1", Collections.emptyList());
+        final DefaultSharderDatabase shard2 = new DefaultSharderDatabase("shard2", Collections.emptyList());
+
+        final String query1 = "SELECT * FROM person;";
+        AssertionsForClassTypes.assertThat(matcher.match(query1, shard1)).isTrue();
+        AssertionsForClassTypes.assertThat(matcher.match(query1, shard2)).isTrue();
+
+        final String query2 = "SELECT * FROM person WHERE id = 1;";
+        AssertionsForClassTypes.assertThat(matcher.match(query2, shard1)).isTrue();
+        AssertionsForClassTypes.assertThat(matcher.match(query2, shard2)).isTrue();
+    }
 
     @Test
     void select_no_where_statement_with_shard_definition_mod() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.github.seonwkim
 # We can't use '-SNAPSHOT' postfix until com.vanniktech.maven.publish supports publishing SNAPSHOT versions to new oss central
-version=0.0.1
+version=0.0.2
 projectName=Sharder
 projectUrl=https://github.com/seonWKim/sharder
 projectDescription=Sharder is an easy-to-use library to handle application level database sharding


### PR DESCRIPTION
### Motivation:

When database needs no sharding, let users not override `shardDefinition` method 

### Modifications:

Add default implementation for `shardDefinitions` method  

### Result:
