### PR TITLE
Parse "FROM" statement independently

### DIFF
--- a/core/src/main/java/io/github/seonwkim/FirstStatement.java
+++ b/core/src/main/java/io/github/seonwkim/FirstStatement.java
@@ -1,8 +1,0 @@
-package io.github.seonwkim;
-
-/**
- * Represents the first statement in a query such as SELECT, INSERT, UPDATE, DELETE.
- */
-public abstract class FirstStatement extends Statement {
-    public abstract String tableName();
-}

--- a/core/src/main/java/io/github/seonwkim/SimpleQuery.java
+++ b/core/src/main/java/io/github/seonwkim/SimpleQuery.java
@@ -12,7 +12,7 @@ import io.github.seonwkim.query.state.WhereStatement;
  */
 public class SimpleQuery {
 
-    private final FirstStatement firstStatement;
+    private final StatementWithTableMeta statementWithTableMeta;
     @Nullable
     private final Expression conditionExpression;
 
@@ -27,8 +27,8 @@ public class SimpleQuery {
             throw new IllegalStateException("No statement found in the query");
         }
 
-        firstStatement = (FirstStatement) statements.get(0);
-        final StatementType type = firstStatement.getStatementType();
+        statementWithTableMeta = (StatementWithTableMeta) statements.get(0);
+        final StatementType type = statementWithTableMeta.getStatementType();
         switch (type) {
             case QUERY_SELECT, QUERY_UPDATE, QUERY_DELETE:
                 this.conditionExpression = getConditionExpression(statements);
@@ -42,7 +42,7 @@ public class SimpleQuery {
     }
 
     public String tableName() {
-        return firstStatement.tableName();
+        return statementWithTableMeta.tableName();
     }
 
     @Nullable

--- a/core/src/main/java/io/github/seonwkim/StatementType.java
+++ b/core/src/main/java/io/github/seonwkim/StatementType.java
@@ -8,6 +8,7 @@ public enum StatementType {
     QUERY_INSERT,
     QUERY_UPDATE,
     QUERY_DELETE,
+    QUERY_FROM,
     QUERY_WHERE,
 
     EXPR,

--- a/core/src/main/java/io/github/seonwkim/StatementWithTableMeta.java
+++ b/core/src/main/java/io/github/seonwkim/StatementWithTableMeta.java
@@ -1,0 +1,11 @@
+package io.github.seonwkim;
+
+/**
+ * Represents the statements including tableName such as SELECT, INSERT, UPDATE, DELETE.
+ */
+public abstract class StatementWithTableMeta extends Statement {
+    @Nullable
+    public abstract String schemaName();
+
+    public abstract String tableName();
+}

--- a/core/src/main/java/io/github/seonwkim/query/state/DeleteStatement.java
+++ b/core/src/main/java/io/github/seonwkim/query/state/DeleteStatement.java
@@ -1,8 +1,7 @@
 package io.github.seonwkim.query.state;
 
 import io.github.seonwkim.StatementType;
-import io.github.seonwkim.FirstStatement;
-
+import io.github.seonwkim.StatementWithTableMeta;
 import lombok.Getter;
 
 /**
@@ -10,15 +9,14 @@ import lombok.Getter;
  * e.g. DELETE FROM schema.table_name;
  */
 @Getter
-public class DeleteStatement extends FirstStatement {
+public class DeleteStatement extends StatementWithTableMeta {
+
     public static DeleteStatementBuilder builder() {return new DeleteStatementBuilder();}
 
-    private final String schemaName;
-    private final String tableName;
+    private final FromStatement fromStatement;
 
-    DeleteStatement(String schemaName, String tableName) {
-        this.schemaName = schemaName;
-        this.tableName = tableName;
+    DeleteStatement(FromStatement fromStatement) {
+        this.fromStatement = fromStatement;
     }
 
     @Override
@@ -27,33 +25,31 @@ public class DeleteStatement extends FirstStatement {
     }
 
     @Override
+    public String schemaName() {
+        return fromStatement.getSchemaName();
+    }
+
+    @Override
     public String tableName() {
-        return tableName;
+        return fromStatement.getTableName();
     }
 
     public static class DeleteStatementBuilder {
-        private String schemaName;
-        private String tableName;
+        private FromStatement fromStatement;
 
         DeleteStatementBuilder() {}
 
-        public DeleteStatementBuilder schemaName(String schemaName) {
-            this.schemaName = schemaName;
-            return this;
-        }
-
-        public DeleteStatementBuilder tableName(String tableName) {
-            this.tableName = tableName;
+        public DeleteStatementBuilder fromStatement(FromStatement fromStatement) {
+            this.fromStatement = fromStatement;
             return this;
         }
 
         public DeleteStatement build() {
-            return new DeleteStatement(this.schemaName, this.tableName);
+            return new DeleteStatement(this.fromStatement);
         }
 
         public String toString() {
-            return "DeleteStatement.DeleteStatementBuilder(schemaName=" + this.schemaName + ", tableName="
-                   + this.tableName + ")";
+            return "DeleteStatement.DeleteStatementBuilder(fromStatement=" + this.fromStatement + ")";
         }
     }
 }

--- a/core/src/main/java/io/github/seonwkim/query/state/FromStatement.java
+++ b/core/src/main/java/io/github/seonwkim/query/state/FromStatement.java
@@ -1,0 +1,54 @@
+package io.github.seonwkim.query.state;
+
+import io.github.seonwkim.Statement;
+import io.github.seonwkim.StatementType;
+import lombok.Getter;
+
+/**
+ * Represents a FROM statement in SQL. Note that {@code schemaName} is optional.<br>
+ * e.g. FROM schema.table_name;
+ */
+@Getter
+public class FromStatement extends Statement {
+
+    public static FromStatementBuilder builder() {return new FromStatementBuilder();}
+
+    private final String schemaName;
+    private final String tableName;
+
+    FromStatement(String schemaName, String tableName) {
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+    }
+
+    @Override
+    public StatementType getStatementType() {
+        return StatementType.QUERY_FROM;
+    }
+
+    public static class FromStatementBuilder {
+        private String schemaName;
+        private String tableName;
+
+        FromStatementBuilder() {}
+
+        public FromStatementBuilder schemaName(String schemaName) {
+            this.schemaName = schemaName;
+            return this;
+        }
+
+        public FromStatementBuilder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public FromStatement build() {
+            return new FromStatement(this.schemaName, this.tableName);
+        }
+
+        public String toString() {
+            return "FromStatement.FromStatementBuilder(schemaName=" + this.schemaName + ", tableName="
+                   + this.tableName + ")";
+        }
+    }
+}

--- a/core/src/main/java/io/github/seonwkim/query/state/InsertStatement.java
+++ b/core/src/main/java/io/github/seonwkim/query/state/InsertStatement.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.github.seonwkim.StatementType;
-import io.github.seonwkim.FirstStatement;
+import io.github.seonwkim.StatementWithTableMeta;
 import io.github.seonwkim.Nullable;
 import io.github.seonwkim.Token;
 import io.github.seonwkim.query.state.expr.ConditionExpression;
@@ -16,7 +16,7 @@ import lombok.Getter;
  * e.g. INSERT INTO schema.table_name (column1, column2) VALUES (value1, value2);
  */
 @Getter
-public class InsertStatement extends FirstStatement {
+public class InsertStatement extends StatementWithTableMeta {
     public static InsertStatementBuilder builder() {return new InsertStatementBuilder();}
 
     private final List<Token> columns;
@@ -52,6 +52,11 @@ public class InsertStatement extends FirstStatement {
     @Override
     public StatementType getStatementType() {
         return StatementType.QUERY_INSERT;
+    }
+
+    @Override
+    public String schemaName() {
+        return schemaName;
     }
 
     @Override

--- a/core/src/main/java/io/github/seonwkim/query/state/SelectStatement.java
+++ b/core/src/main/java/io/github/seonwkim/query/state/SelectStatement.java
@@ -3,9 +3,7 @@ package io.github.seonwkim.query.state;
 import java.util.List;
 
 import io.github.seonwkim.StatementType;
-import io.github.seonwkim.FirstStatement;
-import io.github.seonwkim.Nullable;
-
+import io.github.seonwkim.StatementWithTableMeta;
 import lombok.Getter;
 
 /**
@@ -13,25 +11,19 @@ import lombok.Getter;
  * e.g. SELECT column1, column2 FROM schema.table_name;
  */
 @Getter
-public class SelectStatement extends FirstStatement {
+public class SelectStatement extends StatementWithTableMeta {
+
     public static SelectStatementBuilder builder() {return new SelectStatementBuilder();}
 
     private final boolean selectStar;
     private final List<String> fields;
-    @Nullable
-    private final String schemaName;
-    private final String tableName;
+    private final FromStatement fromStatement;
 
-    SelectStatement(boolean selectStar, List<String> fields, @Nullable String schemaName, String tableName) {
+    SelectStatement(boolean selectStar, List<String> fields, FromStatement fromStatement) {
         this.selectStar = selectStar;
         this.fields = fields;
-        this.schemaName = schemaName;
-        this.tableName = tableName;
+        this.fromStatement = fromStatement;
     }
-
-    private static boolean $default$selectStar() {return false;}
-
-    private static List<String> $default$fields() {return List.of();}
 
     @Override
     public StatementType getStatementType() {
@@ -39,58 +31,44 @@ public class SelectStatement extends FirstStatement {
     }
 
     @Override
+    public String schemaName() {
+        return fromStatement.getSchemaName();
+    }
+
+    @Override
     public String tableName() {
-        return tableName;
+        return fromStatement.getTableName();
     }
 
     public static class SelectStatementBuilder {
-        private boolean selectStar$value;
-        private boolean selectStar$set;
-        private List<String> fields$value;
-        private boolean fields$set;
-        private @Nullable String schemaName;
-        private String tableName;
+        private boolean selectStar;
+        private List<String> fields;
+        private FromStatement fromStatement;
 
         SelectStatementBuilder() {}
 
         public SelectStatementBuilder selectStar(boolean selectStar) {
-            this.selectStar$value = selectStar;
-            this.selectStar$set = true;
+            this.selectStar = selectStar;
             return this;
         }
 
         public SelectStatementBuilder fields(List<String> fields) {
-            this.fields$value = fields;
-            this.fields$set = true;
+            this.fields = fields;
             return this;
         }
 
-        public SelectStatementBuilder schemaName(@Nullable String schemaName) {
-            this.schemaName = schemaName;
-            return this;
-        }
-
-        public SelectStatementBuilder tableName(String tableName) {
-            this.tableName = tableName;
+        public SelectStatementBuilder fromStatement(FromStatement fromStatement) {
+            this.fromStatement = fromStatement;
             return this;
         }
 
         public SelectStatement build() {
-            boolean selectStar$value = this.selectStar$value;
-            if (!this.selectStar$set) {
-                selectStar$value = SelectStatement.$default$selectStar();
-            }
-            List<String> fields$value = this.fields$value;
-            if (!this.fields$set) {
-                fields$value = SelectStatement.$default$fields();
-            }
-            return new SelectStatement(selectStar$value, fields$value, this.schemaName, this.tableName);
+            return new SelectStatement(this.selectStar, this.fields, this.fromStatement);
         }
 
         public String toString() {
-            return "SelectStatement.SelectStatementBuilder(selectStar$value=" + this.selectStar$value
-                   + ", fields$value=" + this.fields$value + ", schemaName=" + this.schemaName + ", tableName="
-                   + this.tableName + ")";
+            return "SelectStatement.SelectStatementBuilder(selectStar=" + this.selectStar + ", fields="
+                   + this.fields + ", fromStatement=" + this.fromStatement + ")";
         }
     }
 }

--- a/core/src/main/java/io/github/seonwkim/query/state/UpdateStatement.java
+++ b/core/src/main/java/io/github/seonwkim/query/state/UpdateStatement.java
@@ -3,9 +3,8 @@ package io.github.seonwkim.query.state;
 import java.util.List;
 
 import io.github.seonwkim.StatementType;
-import io.github.seonwkim.FirstStatement;
+import io.github.seonwkim.StatementWithTableMeta;
 import io.github.seonwkim.Token;
-
 import lombok.Getter;
 
 /**
@@ -13,7 +12,7 @@ import lombok.Getter;
  * e.g. UPDATE schema.table_name SET column1 = value1, column2 = value2;
  */
 @Getter
-public class UpdateStatement extends FirstStatement {
+public class UpdateStatement extends StatementWithTableMeta {
     public static UpdateStatementBuilder builder() {return new UpdateStatementBuilder();}
 
     private final String schemaName;
@@ -31,6 +30,11 @@ public class UpdateStatement extends FirstStatement {
     @Override
     public StatementType getStatementType() {
         return StatementType.QUERY_UPDATE;
+    }
+
+    @Override
+    public String schemaName() {
+        return schemaName;
     }
 
     @Override

--- a/core/src/test/java/io/github/seonwkim/query/QueryParserTest.java
+++ b/core/src/test/java/io/github/seonwkim/query/QueryParserTest.java
@@ -37,7 +37,7 @@ class QueryParserTest {
         final SelectStatement selectStatement = (SelectStatement) statement.get(0);
         assertTrue(selectStatement.isSelectStar());
         assertThat(selectStatement.getFields()).isEmpty();
-        assertThat(selectStatement.getTableName()).isEqualTo("members");
+        assertThat(selectStatement.tableName()).isEqualTo("members");
 
         assertThat(statement.get(1).getClass()).isEqualTo(ExpressionStatement.class);
         final ExpressionStatement expressionStatement = (ExpressionStatement) statement.get(1);
@@ -55,8 +55,8 @@ class QueryParserTest {
         final SelectStatement selectStatement = (SelectStatement) statement.get(0);
         assertFalse(selectStatement.isSelectStar());
         assertThat(selectStatement.getFields()).containsExactly("id", "age", "databaseName");
-        assertThat(selectStatement.getSchemaName()).isNull();
-        assertThat(selectStatement.getTableName()).isEqualTo("members");
+        assertThat(selectStatement.schemaName()).isNull();
+        assertThat(selectStatement.tableName()).isEqualTo("members");
     }
 
     @Test
@@ -70,8 +70,8 @@ class QueryParserTest {
         final SelectStatement selectStatement = (SelectStatement) statement.get(0);
         assertTrue(selectStatement.isSelectStar());
         assertThat(selectStatement.getFields()).isEmpty();
-        assertThat(selectStatement.getSchemaName()).isEqualTo("test");
-        assertThat(selectStatement.getTableName()).isEqualTo("members");
+        assertThat(selectStatement.schemaName()).isEqualTo("test");
+        assertThat(selectStatement.tableName()).isEqualTo("members");
 
         assertThat(statement.get(1).getClass()).isEqualTo(ExpressionStatement.class);
         final ExpressionStatement expressionStatement = (ExpressionStatement) statement.get(1);
@@ -89,8 +89,8 @@ class QueryParserTest {
         final SelectStatement selectStatement = (SelectStatement) statement.get(0);
         assertTrue(selectStatement.isSelectStar());
         assertThat(selectStatement.getFields()).isEmpty();
-        assertThat(selectStatement.getSchemaName()).isEqualTo("test");
-        assertThat(selectStatement.getTableName()).isEqualTo("members");
+        assertThat(selectStatement.schemaName()).isEqualTo("test");
+        assertThat(selectStatement.tableName()).isEqualTo("members");
 
         assertThat(statement.get(1).getClass()).isEqualTo(WhereStatement.class);
         final WhereStatement expressionStatement = (WhereStatement) statement.get(1);
@@ -120,19 +120,25 @@ class QueryParserTest {
         assertThat(statement.get(1).getClass()).isEqualTo(WhereStatement.class);
         final WhereStatement whereExpression = (WhereStatement) statement.get(1);
 
-        AssertionsForClassTypes.assertThat(whereExpression.getExpression().getClass()).isEqualTo(ConditionExpression.class);
+        AssertionsForClassTypes.assertThat(whereExpression.getExpression().getClass()).isEqualTo(
+                ConditionExpression.class);
         final ConditionExpression conditionExpression1 = (ConditionExpression) whereExpression.getExpression();
         assertThat(conditionExpression1.getTree().getTokens().size()).isEqualTo(5);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(0).type()).isEqualTo(
-                TokenType.LEFT_PAREN);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(1).type()).isEqualTo(
-                TokenType.IDENTIFIER);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(2).type()).isEqualTo(
-                TokenType.EQUAL);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(3).type()).isEqualTo(
-                TokenType.NUMBER);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(4).type()).isEqualTo(
-                TokenType.RIGHT_PAREN);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(0).type())
+                                   .isEqualTo(
+                                           TokenType.LEFT_PAREN);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(1).type())
+                                   .isEqualTo(
+                                           TokenType.IDENTIFIER);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(2).type())
+                                   .isEqualTo(
+                                           TokenType.EQUAL);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(3).type())
+                                   .isEqualTo(
+                                           TokenType.NUMBER);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression1.getTree().getTokens().get(4).type())
+                                   .isEqualTo(
+                                           TokenType.RIGHT_PAREN);
     }
 
     @Test
@@ -144,8 +150,10 @@ class QueryParserTest {
 
         assertThat(statement.get(1).getClass()).isEqualTo(WhereStatement.class);
         final WhereStatement expressionStatement = (WhereStatement) statement.get(1);
-        AssertionsForClassTypes.assertThat(expressionStatement.getExpression().getClass()).isEqualTo(ConditionExpression.class);
-        final ConditionExpression conditionExpression = (ConditionExpression) expressionStatement.getExpression();
+        AssertionsForClassTypes.assertThat(expressionStatement.getExpression().getClass()).isEqualTo(
+                ConditionExpression.class);
+        final ConditionExpression conditionExpression =
+                (ConditionExpression) expressionStatement.getExpression();
 
         final List<Token> whereExpressionTokens = conditionExpression.getTree().getTokens();
         assertThat(whereExpressionTokens.size()).isEqualTo(7);
@@ -171,8 +179,10 @@ class QueryParserTest {
 
         assertThat(statement.get(1).getClass()).isEqualTo(WhereStatement.class);
         final WhereStatement expressionStatement = (WhereStatement) statement.get(1);
-        AssertionsForClassTypes.assertThat(expressionStatement.getExpression().getClass()).isEqualTo(ConditionExpression.class);
-        final ConditionExpression conditionExpression = (ConditionExpression) expressionStatement.getExpression();
+        AssertionsForClassTypes.assertThat(expressionStatement.getExpression().getClass()).isEqualTo(
+                ConditionExpression.class);
+        final ConditionExpression conditionExpression =
+                (ConditionExpression) expressionStatement.getExpression();
 
         final List<Token> whereExpressionTokens = conditionExpression.getTree().getTokens();
         assertThat(whereExpressionTokens.size()).isEqualTo(7);
@@ -200,8 +210,10 @@ class QueryParserTest {
         assertThat(statement.get(0).getClass()).isEqualTo(SelectStatement.class);
         assertThat(statement.get(1).getClass()).isEqualTo(WhereStatement.class);
         final WhereStatement expressionStatement = (WhereStatement) statement.get(1);
-        AssertionsForClassTypes.assertThat(expressionStatement.getExpression().getClass()).isEqualTo(ConditionExpression.class);
-        final ConditionExpression conditionExpression = (ConditionExpression) expressionStatement.getExpression();
+        AssertionsForClassTypes.assertThat(expressionStatement.getExpression().getClass()).isEqualTo(
+                ConditionExpression.class);
+        final ConditionExpression conditionExpression =
+                (ConditionExpression) expressionStatement.getExpression();
 
         final List<Token> whereExpressionTokens = conditionExpression.getTree().getTokens();
         assertThat(whereExpressionTokens.size()).isEqualTo(7);
@@ -224,8 +236,8 @@ class QueryParserTest {
         assertThat(statement.get(0).getClass()).isEqualTo(InsertStatement.class);
         final InsertStatement insertStatement = (InsertStatement) statement.get(0);
 
-        assertThat(insertStatement.getSchemaName()).isNull();
-        assertThat(insertStatement.getTableName()).isEqualTo("members");
+        assertThat(insertStatement.schemaName()).isNull();
+        assertThat(insertStatement.tableName()).isEqualTo("members");
 
         AssertionsForInterfaceTypes.assertThat(insertStatement.getColumns().get(0).type()).isEqualTo(
                 TokenType.IDENTIFIER);
@@ -252,8 +264,8 @@ class QueryParserTest {
         assertThat(statement.get(0).getClass()).isEqualTo(InsertStatement.class);
         final InsertStatement insertStatement = (InsertStatement) statement.get(0);
 
-        assertThat(insertStatement.getSchemaName()).isEqualTo("test");
-        assertThat(insertStatement.getTableName()).isEqualTo("members");
+        assertThat(insertStatement.schemaName()).isEqualTo("test");
+        assertThat(insertStatement.tableName()).isEqualTo("members");
 
         AssertionsForInterfaceTypes.assertThat(insertStatement.getColumns().get(0).type()).isEqualTo(
                 TokenType.IDENTIFIER);
@@ -298,8 +310,8 @@ class QueryParserTest {
         assertThat(statement.get(0).getClass()).isEqualTo(UpdateStatement.class);
         final UpdateStatement updateStatement = (UpdateStatement) statement.get(0);
 
-        assertThat(updateStatement.getSchemaName()).isNull();
-        assertThat(updateStatement.getTableName()).isEqualTo("members");
+        assertThat(updateStatement.schemaName()).isNull();
+        assertThat(updateStatement.tableName()).isEqualTo("members");
 
         AssertionsForInterfaceTypes.assertThat(updateStatement.getColumns().get(0).type()).isEqualTo(
                 TokenType.IDENTIFIER);
@@ -325,8 +337,8 @@ class QueryParserTest {
 
         assertThat(statement.get(0).getClass()).isEqualTo(UpdateStatement.class);
         final UpdateStatement updateStatement = (UpdateStatement) statement.get(0);
-        assertThat(updateStatement.getSchemaName()).isEqualTo("test");
-        assertThat(updateStatement.getTableName()).isEqualTo("members");
+        assertThat(updateStatement.schemaName()).isEqualTo("test");
+        assertThat(updateStatement.tableName()).isEqualTo("members");
 
         AssertionsForInterfaceTypes.assertThat(updateStatement.getColumns().get(0).type()).isEqualTo(
                 TokenType.IDENTIFIER);
@@ -352,8 +364,8 @@ class QueryParserTest {
 
         assertThat(statement.get(0).getClass()).isEqualTo(UpdateStatement.class);
         final UpdateStatement updateStatement = (UpdateStatement) statement.get(0);
-        assertThat(updateStatement.getSchemaName()).isNull();
-        assertThat(updateStatement.getTableName()).isEqualTo("members");
+        assertThat(updateStatement.schemaName()).isNull();
+        assertThat(updateStatement.tableName()).isEqualTo("members");
 
         AssertionsForInterfaceTypes.assertThat(updateStatement.getColumns().get(0).type()).isEqualTo(
                 TokenType.IDENTIFIER);
@@ -371,15 +383,19 @@ class QueryParserTest {
 
         assertThat(statement.get(1).getClass()).isEqualTo(WhereStatement.class);
         final WhereStatement whereStatement = (WhereStatement) statement.get(1);
-        AssertionsForClassTypes.assertThat(whereStatement.getExpression().getClass()).isEqualTo(ConditionExpression.class);
+        AssertionsForClassTypes.assertThat(whereStatement.getExpression().getClass()).isEqualTo(
+                ConditionExpression.class);
         final ConditionExpression conditionExpression = (ConditionExpression) whereStatement.getExpression();
         assertThat(conditionExpression.getTree().getTokens().size()).isEqualTo(3);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(0).type()).isEqualTo(
-                TokenType.IDENTIFIER);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(1).type()).isEqualTo(
-                TokenType.EQUAL);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(2).type()).isEqualTo(
-                TokenType.NUMBER);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(0).type())
+                                   .isEqualTo(
+                                           TokenType.IDENTIFIER);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(1).type())
+                                   .isEqualTo(
+                                           TokenType.EQUAL);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(2).type())
+                                   .isEqualTo(
+                                           TokenType.NUMBER);
     }
 
     @Test
@@ -392,8 +408,8 @@ class QueryParserTest {
         assertThat(statement.get(0).getClass()).isEqualTo(DeleteStatement.class);
         final DeleteStatement deleteStatement = (DeleteStatement) statement.get(0);
 
-        assertThat(deleteStatement.getSchemaName()).isNull();
-        assertThat(deleteStatement.getTableName()).isEqualTo("members");
+        assertThat(deleteStatement.schemaName()).isNull();
+        assertThat(deleteStatement.tableName()).isEqualTo("members");
     }
 
     @Test
@@ -406,8 +422,8 @@ class QueryParserTest {
         assertThat(statement.get(0).getClass()).isEqualTo(DeleteStatement.class);
         final DeleteStatement deleteStatement = (DeleteStatement) statement.get(0);
 
-        assertThat(deleteStatement.getSchemaName()).isEqualTo("test");
-        assertThat(deleteStatement.getTableName()).isEqualTo("members");
+        assertThat(deleteStatement.schemaName()).isEqualTo("test");
+        assertThat(deleteStatement.tableName()).isEqualTo("members");
     }
 
     @Test
@@ -419,19 +435,23 @@ class QueryParserTest {
 
         assertThat(statement.get(0).getClass()).isEqualTo(DeleteStatement.class);
         final DeleteStatement deleteStatement = (DeleteStatement) statement.get(0);
-        assertThat(deleteStatement.getSchemaName()).isNull();
-        assertThat(deleteStatement.getTableName()).isEqualTo("members");
+        assertThat(deleteStatement.schemaName()).isNull();
+        assertThat(deleteStatement.tableName()).isEqualTo("members");
 
         assertThat(statement.get(1).getClass()).isEqualTo(WhereStatement.class);
         final WhereStatement whereStatement = (WhereStatement) statement.get(1);
-        AssertionsForClassTypes.assertThat(whereStatement.getExpression().getClass()).isEqualTo(ConditionExpression.class);
+        AssertionsForClassTypes.assertThat(whereStatement.getExpression().getClass()).isEqualTo(
+                ConditionExpression.class);
         final ConditionExpression conditionExpression = (ConditionExpression) whereStatement.getExpression();
         assertThat(conditionExpression.getTree().getTokens().size()).isEqualTo(3);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(0).type()).isEqualTo(
-                TokenType.IDENTIFIER);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(1).type()).isEqualTo(
-                TokenType.EQUAL);
-        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(2).type()).isEqualTo(
-                TokenType.NUMBER);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(0).type())
+                                   .isEqualTo(
+                                           TokenType.IDENTIFIER);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(1).type())
+                                   .isEqualTo(
+                                           TokenType.EQUAL);
+        AssertionsForInterfaceTypes.assertThat(conditionExpression.getTree().getTokens().get(2).type())
+                                   .isEqualTo(
+                                           TokenType.NUMBER);
     }
 }


### PR DESCRIPTION
### Motivation:

Duplicate logic on parsing the `FromStatement` while parsing `SelectStatement` and `DeleteStatement`. Let's extract it into a single method for reuse. 

### Modifications:

- SelectStatement and DeleteStatement will include FromStatement. 
- Rename FirstStatement to StatementWithTableMeta

### Result:

- Closes #<[GitHub issue number](https://github.com/seonWKim/sharder/issues/7)>. (If this resolves the issue.)
- Remove duplicate coe 
